### PR TITLE
[ECOM-1863] updating mail version to 2.6.0

### DIFF
--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('actionpack',  version)
-  s.add_dependency('mail',        '~> 2.5.4')
+  s.add_dependency('mail',        '~> 2.6.0')
 end


### PR DESCRIPTION
Updates Rails 3.2 to depend on a secure version of the `mail` gem.